### PR TITLE
fix: make the plugin build, resolve sessions, and run reviews on Windows

### DIFF
--- a/.bin/codex-review
+++ b/.bin/codex-review
@@ -45,7 +45,40 @@ parent_pid() {
     ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '
 }
 
+# Find the pid of the Claude session whose session file advertises session_id.
+# The session file name is the pid; we confirm via its recorded sessionId.
+session_pid_for_id() {
+    local want="$1"
+    local f sid base
+    for f in "$HOME"/.claude/sessions/*.json; do
+        [[ -f "$f" ]] || continue
+        sid="$(read_session_id "$f")"
+        if [[ "$sid" == "$want" ]]; then
+            base="$(basename "$f")"
+            base="${base%.json}"
+            if [[ "$base" =~ ^[0-9]+$ ]]; then
+                printf '%s\n' "$base"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
 resolve_session_hints() {
+    # Prefer the session id Claude Code exports in the environment. The ps-based
+    # parent walk below does not work on every platform (e.g. Git Bash on
+    # Windows, where `ps -o ppid=` yields nothing), so trust the env var first
+    # and recover the pid from the matching session file.
+    local env_id="${CLAUDE_CODE_SESSION_ID:-}"
+    if [[ "$env_id" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+        local env_pid
+        if env_pid="$(session_pid_for_id "$env_id")"; then
+            printf '%s %s\n' "$env_pid" "$env_id"
+            return 0
+        fi
+    fi
+
     local pid="${PPID:-}"
     local depth=0
     while [[ -n "$pid" && "$pid" =~ ^[0-9]+$ && "$pid" -gt 1 && "$depth" -lt 8 ]]; do

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -113,8 +113,3 @@ func (l *Lock) installSignalHandler() {
 		os.Exit(130)
 	}()
 }
-
-func processAlive(pid int) bool {
-	err := syscall.Kill(pid, 0)
-	return err == nil
-}

--- a/internal/lock/lock_unix.go
+++ b/internal/lock/lock_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package lock
+
+import "syscall"
+
+// processAlive reports whether pid refers to a live process. Signal 0 performs
+// an error-check without delivering a signal: nil means the process exists and
+// is signalable, EPERM means it exists but is owned by another user (so it is
+// alive — treating it as dead would let us steal a live lock), any other error
+// (ESRCH) means it is gone.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/lock/lock_windows.go
+++ b/internal/lock/lock_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package lock
+
+import "syscall"
+
+const (
+	// Constants not exported by the syscall package.
+	processQueryLimitedInformation = 0x1000 // PROCESS_QUERY_LIMITED_INFORMATION
+	stillActive                    = 259    // STILL_ACTIVE
+)
+
+// processAlive reports whether pid refers to a live process.
+//
+// Windows has no signal-0 liveness probe. os.FindProcess is not sufficient: a
+// terminated process stays openable while any handle to it remains, so a
+// successful open does not imply the process is running, and an access-denied
+// error actually proves the process exists (e.g. an elevated owner). We open
+// with PROCESS_QUERY_LIMITED_INFORMATION — which succeeds across elevation
+// boundaries — and read the exit code to distinguish a live process from a
+// still-openable corpse.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		// Access denied means the process exists but is protected; treating it
+		// as dead would let us steal a live lock. Any other error (e.g. invalid
+		// parameter for an unknown pid) means it is gone.
+		return err == syscall.ERROR_ACCESS_DENIED
+	}
+	defer syscall.CloseHandle(h)
+	var code uint32
+	if err := syscall.GetExitCodeProcess(h, &code); err != nil {
+		return true // we opened it; fail toward "held"
+	}
+	// A process that deliberately exits with 259 reads as alive; Microsoft
+	// documents not using STILL_ACTIVE as an exit code, so this is acceptable.
+	return code == stillActive
+}

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -67,11 +67,17 @@ func codexExecOnce(cfg config.Config, prompt, outputFile string, flags []string,
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	args := []string{"exec", prompt}
+	// Pass the prompt via stdin ("codex exec -") instead of as a command-line
+	// argument. Review prompts can be large, and a big argv blows past the
+	// command-line length limit — on Windows the CLI resolves to codex.cmd
+	// (cmd.exe, ~8191 chars), which silently truncates the tail, dropping
+	// trailing flags like -m and falling back to the config.toml model.
+	args := []string{"exec", "-"}
 	args = append(args, flags...)
 	args = append(args, "--output-last-message", outputFile, "-m", cfg.CodexModel)
 
 	cmd := exec.CommandContext(ctx, "codex", args...)
+	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -283,7 +283,10 @@ func resolvePlanFromSession(home string, session *claudeRuntimeSession) (string,
 	for _, transcript := range transcripts {
 		path, err := resolvePlanFromTranscript(home, transcript)
 		if err != nil {
-			return "", err
+			// A malformed or unreadable candidate (e.g. an invalid path on
+			// Windows) must not abort resolution: later candidates from the
+			// glob fallback may still hold the plan.
+			continue
 		}
 		if strings.TrimSpace(path) != "" {
 			return path, nil
@@ -682,7 +685,20 @@ func encodeClaudeProjectKey(cwd string) string {
 	if clean == "." || clean == "" {
 		return ""
 	}
-	return strings.ReplaceAll(clean, string(filepath.Separator), "-")
+	// Claude Code names the transcript directory after the cwd with every
+	// character outside [A-Za-z0-9] replaced by '-'. Replacing only the OS path
+	// separator leaves Windows drive colons and spaces intact, producing a path
+	// that is invalid on Windows (e.g. "D:-Claude prototypes-roads-to-ruin").
+	var b strings.Builder
+	b.Grow(len(clean))
+	for _, r := range clean {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
 }
 
 func isValidClaudePlanPath(path string) bool {


### PR DESCRIPTION
Four independent Windows-portability fixes. Together they take the plugin from *does not build* to *completes a full plan/impl review round* on Windows (Git Bash / MSYS). Each is its own commit; Unix behaviour is unchanged throughout. Verified end-to-end on `windows/amd64` (go 1.26, codex-cli 0.144): a `plan` round now creates the workflow and writes a real Codex review.

### 1. Cross-platform process-liveness check — *fixes the build*
`processAlive` used `syscall.Kill(pid, 0)`, undefined on Windows, so `go build ./...` failed and the shim's on-first-use build never produced a binary. Split by build tag:
- `lock_unix.go` (`//go:build !windows`) — keeps `kill(pid, 0)`; now also treats `EPERM` as alive (a live process owned by another user isn't a stale lock).
- `lock_windows.go` — `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess`. `os.FindProcess` is unsuitable (a terminated process stays openable while any handle remains → success ≠ running; access-denied *proves* existence). Exit code `!= STILL_ACTIVE` distinguishes a live process from a still-openable corpse. No new deps.

### 2. Resolve the Claude session from the environment — *fixes session-scoped commands*
The shim inferred the session by walking the parent-process chain with `ps -o ppid=`, which returns nothing on Windows, so `plan`/`impl`/`status`/`summary` reported "no Claude session." It now prefers `CLAUDE_CODE_SESSION_ID` (which Claude Code exports), recovering the pid from the matching `~/.claude/sessions/<pid>.json`, and falls back to the `ps` walk.

### 3. Build a valid Claude transcript path on Windows — *fixes `plan` crashing*
`encodeClaudeProjectKey` replaced only the OS path separator, leaving drive colons and spaces, so cwd `D:\Claude prototypes\roads-to-ruin` became `D:-Claude prototypes-roads-to-ruin` — an invalid Windows filename. Opening it returned `ERROR_INVALID_NAME` (not `IsNotExist`), aborting resolution before the glob fallback that would have found the real transcript. Now encodes the key the way Claude Code does (every char outside `[A-Za-z0-9]` → `-`) and skips a candidate that errors instead of aborting.

### 4. Send the Codex prompt over stdin — *fixes reviews silently using the wrong model*
The runner passed the whole review prompt as an argv element. On Windows `codex` resolves to `codex.cmd` (cmd.exe, ~8191-char command-line limit); large prompts pushed the trailing flags (`--output-last-message`, `-m <model>`) past the limit, cmd.exe truncated them, and Codex silently fell back to the `config.toml` model — which 400s if that model needs a newer Codex than the resolved CLI. Now uses `codex exec -` and feeds the prompt via `cmd.Stdin`, so the command line carries only short flags and can never be truncated regardless of how `codex` resolves.

---

**Testing note:** `go build`/`vet ./...` pass on windows/amd64 and cross-compile clean for linux and darwin; `go test ./internal/lock` passes on Windows. The `internal/engine` review tests use a fake `codex` stub written as an extensionless `#!/bin/bash` script (`setupFakeWorkflowCodex`), which Windows' `exec.LookPath` can't resolve and cmd can't execute — so those tests are inherently Unix-only and are unaffected by these changes (the stub keys only off `--output-last-message`, which is untouched). Making that harness cross-platform is a separate change I'm happy to add if you'd like.